### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/packages/pyright-internal/src/analyzer/typePrinterUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinterUtils.ts
@@ -15,8 +15,10 @@ export function printStringLiteral(value: string, quotation = '"'): string {
     // So, we only need to do our own escaping for ' case.
     let literalStr = JSON.stringify(value).toString();
     if (quotation !== '"') {
+        const backslashRegEx = /\\/g;
         literalStr = `'${literalStr
             .substring(1, literalStr.length - 1)
+            .replace(backslashRegEx, '\\\\')
             .replace(escapedDoubleQuoteRegEx, '"')
             .replace(singleTickRegEx, "\\'")}'`; // CodeQL [SM02383] Code ql is just wrong here. We don't need to replace backslashes.
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Aeonsmith/pyright/security/code-scanning/1](https://github.com/Aeonsmith/pyright/security/code-scanning/1)

To fix the problem, we need to ensure that backslashes are properly escaped in the `printStringLiteral` function. This can be done by adding a regular expression to replace backslashes with double backslashes before performing other replacements. This ensures that all occurrences of backslashes are correctly escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
